### PR TITLE
Fix issue with database version caching

### DIFF
--- a/ACE.Mods.Metrics/PatchClass.cs
+++ b/ACE.Mods.Metrics/PatchClass.cs
@@ -25,13 +25,12 @@ public class PatchClass(BasicMod mod, string settingsName = "Settings.json") : B
         return Task.CompletedTask;
     }
 
-    //public override Task OnWorldOpen()
-    //{
-    //    Settings = SettingsContainer?.Settings ?? new();
-    //    StartServices();
+    public override Task OnWorldOpen()
+    {
+        PrometheusMetrics.UpdateDatabaseVersion();
 
-    //    return Task.CompletedTask;
-    //}
+        return Task.CompletedTask;
+    }
 
     //protected override void SettingsChanged(object sender, EventArgs e)
     //{

--- a/ACE.Mods.Metrics/PrometheusMetrics.cs
+++ b/ACE.Mods.Metrics/PrometheusMetrics.cs
@@ -158,9 +158,16 @@ public static class PrometheusMetrics
 
         if (database_Base_Version is null && DatabaseManager.World is not null)
         {
-            var dbVersion = DatabaseManager.World.GetVersion();
-            database_Base_Version = dbVersion.BaseVersion;
-            database_Patch_Version = dbVersion.PatchVersion;
+            try
+            {
+                var dbVersion = DatabaseManager.World.GetVersion();
+                database_Base_Version = dbVersion.BaseVersion;
+                database_Patch_Version = dbVersion.PatchVersion;
+            }
+            catch (Exception)
+            {
+
+            }
         }
 
         ace_Info.WithLabels(ServerBuildInfo.FullVersion, database_Base_Version ?? "", database_Patch_Version ?? "").Set(1);
@@ -331,5 +338,17 @@ public static class PrometheusMetrics
             ace_HouseManager_TotalOwnedMansions.Set(totalOwnedMansions);
         else
             ace_HouseManager_TotalOwnedMansions.Set(0);
+    }
+
+    public static void UpdateDatabaseVersion()
+    {
+        ace_Info.RemoveLabelled(ServerBuildInfo.FullVersion, database_Base_Version ?? "", database_Patch_Version ?? "");
+
+        if (DatabaseManager.World is not null)
+        {
+            var dbVersion = DatabaseManager.World.GetVersion();
+            database_Base_Version = dbVersion.BaseVersion;
+            database_Patch_Version = dbVersion.PatchVersion;
+        }
     }
 }


### PR DESCRIPTION
Plugin will now update cached database version when world opens.

This catching instances where plugin has cached version after world started up but before the auto updater checked and updated to latest world release

Also prevents missing world version from throwing exception